### PR TITLE
Add invited person and space for custom data to the model

### DIFF
--- a/common/request-model.js
+++ b/common/request-model.js
@@ -92,6 +92,17 @@ export class Request extends LinkableModel(BaseModel) {
     }
 
     /**
+     * Get the User instance for the user who is invited if exists
+     * @returns {User} The user who is invited
+     */
+    invited() {
+        if (this.invited) {
+            return Meteor.users.findOne({ _id: this.invited });
+        }
+        return null;
+    }
+
+    /**
      * Accept the request
      */
     accept() {
@@ -144,7 +155,15 @@ RequestsCollection.attachSchema(new SimpleSchema({
             }
             return undefined;
         },
+        index: 1,
         denyUpdate: true,
+    },
+    invitedId: {
+        type: String,
+        regEx: SimpleSchema.RegEx.Id,
+        index: 1,
+        denyUpdate: true,
+        optional: true
     },
     type: {
         type: String,
@@ -169,6 +188,11 @@ RequestsCollection.attachSchema(new SimpleSchema({
         type: Date,
         optional: true,
     },
+    data: {
+        type: Object,
+        blackbox: true,
+        optional: true
+    }
 }));
 
 // add the LinkableSchema to the request class


### PR DESCRIPTION
* Adds a field for an invited user and extra data.
* Adds indexes where I think appropriate (I think they are also missing in other packages, most notable feed).

**Scenario to support this case**
I have a story that can be translated. I want to invite a translator to translate the story from `en` to `jp`.
I want to display to the invited user message on their home screen saying something like this: `You have been invited by {request.requesterId} to translate {request.linkedObjectId} into {request.data.language}.`
When the invited user accepts the invite the `onAccepted` function will need the invited user's id, the linked object id and the language for which to grant the translation privileges to perform the needed action.